### PR TITLE
Remove guru.nidi.graphviz-java library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,6 @@
         </dependency>
 
         <dependency>
-            <groupId>guru.nidi</groupId>
-            <artifactId>graphviz-java</artifactId>
-            <version>0.8.3</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.jgrapht</groupId>
             <artifactId>jgrapht-core</artifactId>
             <version>1.3.0</version>

--- a/src/main/java/tfm/exec/CFGLog.java
+++ b/src/main/java/tfm/exec/CFGLog.java
@@ -1,15 +1,8 @@
 package tfm.exec;
 
 import com.github.javaparser.ast.Node;
-import guru.nidi.graphviz.engine.Format;
-import guru.nidi.graphviz.engine.Graphviz;
 import tfm.graphs.CFGGraph;
-import tfm.utils.FileUtil;
 import tfm.visitors.cfg.CFGBuilder;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
 
 public class CFGLog extends GraphLog<CFGGraph> {
 

--- a/src/main/java/tfm/exec/PDGLog.java
+++ b/src/main/java/tfm/exec/PDGLog.java
@@ -1,6 +1,5 @@
 package tfm.exec;
 
-import guru.nidi.graphviz.engine.Format;
 import tfm.graphs.PDGGraph;
 import tfm.nodes.GraphNode;
 import tfm.utils.Logger;


### PR DESCRIPTION
Fixes #8

This removes ~20MB from a packaged `jar` executable and lowers the resources needed on runtime (less classes loaded into memory).