### PR TITLE
OUT nodes not generated for primitive types or literals

### DIFF
--- a/src/main/java/tfm/arcs/Arc.java
+++ b/src/main/java/tfm/arcs/Arc.java
@@ -7,7 +7,6 @@ import tfm.arcs.pdg.ControlDependencyArc;
 import tfm.arcs.pdg.DataDependencyArc;
 import tfm.arcs.sdg.CallArc;
 import tfm.arcs.sdg.ParameterInOutArc;
-import tfm.arcs.sdg.ReturnArc;
 import tfm.arcs.sdg.SummaryArc;
 import tfm.nodes.GraphNode;
 
@@ -85,17 +84,6 @@ public abstract class Arc extends DefaultEdge {
         if (isParameterInOutArc())
             return (ParameterInOutArc) this;
         throw new UnsupportedOperationException("Not a ParameterInOutArc");
-    }
-
-    /** @see ReturnArc */
-    public final boolean isReturnArc() {
-        return this instanceof ReturnArc;
-    }
-
-    public final ReturnArc asReturnArc() {
-        if (isReturnArc())
-            return (ReturnArc) this;
-        throw new UnsupportedOperationException("Not a ReturnArc");
     }
 
     /** @see SummaryArc */

--- a/src/main/java/tfm/graphs/cfg/CFGBuilder.java
+++ b/src/main/java/tfm/graphs/cfg/CFGBuilder.java
@@ -309,8 +309,14 @@ public class CFGBuilder extends VoidVisitorAdapter<Void> {
         returnList.stream().filter(node -> !hangingNodes.contains(node)).forEach(hangingNodes::add);
 
         // Create and connect formal-out nodes sequentially
-        for (Parameter param : methodDeclaration.getParameters())
+        for (Parameter param : methodDeclaration.getParameters()) {
+            // Do not generate out for primitives
+            if (param.getType().isPrimitiveType()) {
+                continue;
+            }
+
             connectTo(addFormalOutGraphNode(param));
+        }
         // Create and connect the exit node
         connectTo(graph.addNode("Exit", new EmptyStmt(), TypeNodeFactory.fromType(NodeType.METHOD_EXIT)));
     }

--- a/src/main/java/tfm/graphs/sdg/MethodCallReplacerVisitor.java
+++ b/src/main/java/tfm/graphs/sdg/MethodCallReplacerVisitor.java
@@ -110,10 +110,6 @@ class MethodCallReplacerVisitor extends VoidVisitorAdapter<Context> {
         GraphNode<MethodDeclaration> methodDeclarationNode = optionalNethodDeclarationNode.get();
         MethodDeclaration methodDeclaration = methodDeclarationNode.getAstNode();
 
-        Optional<CFG> optionalCFG = sdg.getMethodCFG(methodDeclaration);
-        assert optionalCFG.isPresent();
-        CFG methodCFG = optionalCFG.get();
-
         GraphNode<MethodCallExpr> methodCallNode = sdg.addNode("CALL " + methodCallExpr.toString(), methodCallExpr, TypeNodeFactory.fromType(NodeType.METHOD_CALL));
 
         sdg.addControlDependencyArc(originalMethodCallNode, methodCallNode);
@@ -182,32 +178,8 @@ class MethodCallReplacerVisitor extends VoidVisitorAdapter<Context> {
 
             // Out expression
 
-            OutNodeVariableVisitor shouldHaveOutNodeVisitor = new OutNodeVariableVisitor();
-            Set<String> variablesForOutNode = new HashSet<>();
-            argument.accept(shouldHaveOutNodeVisitor, variablesForOutNode);
-
-            // Here, variablesForOutNode may have 1 variable or more depending on the expression
-
-            Logger.log("MethodCallReplacerVisitor", String.format("Variables for out node: %s", variablesForOutNode));
-            if (variablesForOutNode.isEmpty()) {
-                /*
-                    If the argument is not a variable or it is not declared in the scope,
-                    then there is no OUT node
-                 */
-                Logger.log("MethodCallReplacerVisitor", String.format("Expression '%s' should not have out node", argument.toString()));
-                continue;
-            } else if (variablesForOutNode.size() == 1) {
-                String variable = variablesForOutNode.iterator().next();
-
-                List<GraphNode<?>> declarations = sdg.findDeclarationsOfVariable(variable, originalMethodCallNode);
-
-                Logger.log("MethodCallReplacerVisitor", String.format("Declarations of variable: '%s': %s", variable, declarations));
-
-                if (declarations.isEmpty()) {
-                    Logger.log("MethodCallReplacerVisitor", String.format("Expression '%s' should not have out node", argument.toString()));
-                    continue;
-                }
-            } else {
+            // If argument is primitive or not a variable, do not generate out nodes
+            if (parameter.getType().isPrimitiveType() || !argument.isNameExpr()) {
                 continue;
             }
 
@@ -282,10 +254,6 @@ class MethodCallReplacerVisitor extends VoidVisitorAdapter<Context> {
         sdg.addParameterInOutArc(declarationOutputNode, callReturnNode);
 
         Logger.log("MethodCallReplacerVisitor", String.format("%s | Method '%s' called", methodCallExpr, methodDeclaration.getNameAsString()));
-    }
-
-    private void argumentAsNameExpr(GraphNode<ExpressionStmt> methodCallNode) {
-
     }
 
     @Override


### PR DESCRIPTION
Changes:
- `formal_out` nodes are generated only if the parameter type is not primitive
- `actual_out` nodes are generated only if these conditions are met:
    - Parameter type is not primitive
    - Argument is a name expression (variable)